### PR TITLE
add possibility to link to a station using ?ge_id=

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -145,6 +145,10 @@ class App {
       });
     }
 
+    var newurl = window.location.protocol + "//" + window.location.host + window.location.pathname +
+        '?poi_id=' + this.currentStation.id + '&poi_source=' + this.currentStation.dataAdapter;
+    window.history.pushState({path: newurl}, '', newurl);
+
     await this.updatePrices();
     this.sidebar.showStation(this.currentStation);
     this.selectedChargePointChanged();

--- a/src/app.js
+++ b/src/app.js
@@ -130,7 +130,7 @@ class App {
     },this.translation.get("errorStationsUnavailable"));
   }
 
-  async stationSelected(model,powerType,centerOnPosition) {
+  async stationSelected(model,powerType,updateMap) {
     this.analytics.log('send', 'event', 'Station', powerType);
 
     await this.withNetwork(async ()=>{
@@ -138,11 +138,12 @@ class App {
       this.currentStation = await (new FetchStations()).detail(model, options);
     },this.translation.get("errorStationsUnavailable"));
     
-    if (centerOnPosition) {
+    if (updateMap) {
       this.map.centerLocation({
         latitude: this.currentStation.latitude,
         longitude: this.currentStation.longitude
       });
+      this.map.changeSelectedStation(this.currentStation)
     }
 
     var newurl = window.location.protocol + "//" + window.location.host + window.location.pathname +

--- a/src/app.js
+++ b/src/app.js
@@ -59,10 +59,13 @@ class App {
       this.map.centerLocation(coords);
       this.map.setSearchLocation(coords);
     });
-    
-    var geId = new URL(window.location.href).searchParams.get("ge_id")
-    if (geId != null) {
-      this.geId = geId;
+
+    var params = new URL(window.location.href).searchParams;
+    var poiId = params.get("poi_id")
+    var poiSource = params.get("poi_source")
+    if (poiId != null && poiSource != null) {
+      this.poiId = poiId;
+      this.poiSource = poiSource;
     } else {
       this.getCurrentLocation();
       this.sidebar.open("settings");
@@ -99,10 +102,10 @@ class App {
     $("#loadingIndicator").toggle(value);
   }
   
-  async showStationById(geId) {
+  async showStationById(poiId, poiSource) {
     this.stationSelected({
-      id: geId,
-      dataAdapter: "going_electric",
+      id: poiId,
+      dataAdapter: poiSource,
       charge_points: []
     }, ">3.7", true)
   }
@@ -200,9 +203,8 @@ class App {
   }
 
   optionsChanged(){
-    if (this.geId != undefined){
-      this.showStationById(this.geId);
-      this.geId = null;
+    if (this.poiId !== undefined && this.poiSource !== undefined) {
+      this.showStationById(this.poiId, this.poiSource);
     }
     this.showStationsAtLocation(this.map.getBounds());
   }


### PR DESCRIPTION
With this change, it is possible to directly show a station with a given ID in the GoingElectric directory. Example: http://localhost:9000/?ge_id=1234

Background: I'm developing a new open source Android app for the GoingElectric charging station directory (https://github.com/johan12345/EVMap) and would like to provide links to Chargeprice.app to directly find the cheapest price for that station. In the future, direct integration through the API would be nice as well (if that is possible free of charge), but a link to the website is probably the easiest solution for now.