### PR TITLE
avoid calling pushState again with same URL

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -154,7 +154,9 @@ class App {
 
     var newurl = window.location.protocol + "//" + window.location.host + window.location.pathname +
         '?poi_id=' + this.currentStation.id + '&poi_source=' + this.currentStation.dataAdapter;
-    window.history.pushState({path: newurl}, '', newurl);
+    if (newUrl != window.location.href) {
+        window.history.pushState({path: newurl}, '', newurl);
+    }
 
     await this.updatePrices();
     this.sidebar.showStation(this.currentStation);


### PR DESCRIPTION
If Chargeprice is launched from a deep link (e.g. https://www.chargeprice.app/?poi_id=1234&poi_source=going_electric), it still calls `window.history.pushState` once with that same URL, which causes an unnecessary entry in the browser's history (i.e. when you press the back button afterwards, nothing happens). This change should fix that problem.